### PR TITLE
Support `Ember.EXTEND_PROTOTYPES.Function`

### DIFF
--- a/dist/amd/macros/mousetrap.js
+++ b/dist/amd/macros/mousetrap.js
@@ -15,7 +15,7 @@ define(
       return callback;
     }
 
-    if (Ember.EXTEND_PROTOTYPES) {
+    if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
       Function.prototype.mousetrap = function(keys, action) {
         return mousetrap(keys, action, this);
       };

--- a/dist/cjs/macros/mousetrap.js
+++ b/dist/cjs/macros/mousetrap.js
@@ -12,7 +12,7 @@ function mousetrap(keys, action, callback) {
   return callback;
 }
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
   Function.prototype.mousetrap = function(keys, action) {
     return mousetrap(keys, action, this);
   };

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -22,7 +22,7 @@ function mousetrap(keys, action, callback) {
   return callback;
 }
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
   Function.prototype.mousetrap = function(keys, action) {
     return mousetrap(keys, action, this);
   };

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -27,7 +27,7 @@ define("ember-mousetrap/macros/mousetrap",
       return callback;
     }
 
-    if (Ember.EXTEND_PROTOTYPES) {
+    if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
       Function.prototype.mousetrap = function(keys, action) {
         return mousetrap(keys, action, this);
       };

--- a/lib/macros/mousetrap.js
+++ b/lib/macros/mousetrap.js
@@ -11,7 +11,7 @@ function mousetrap(keys, action, callback) {
   return callback;
 }
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
   Function.prototype.mousetrap = function(keys, action) {
     return mousetrap(keys, action, this);
   };


### PR DESCRIPTION
This option is supported on Ember.js.
ref: http://emberjs.com/api/classes/Function.html
