### PR TITLE
jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,8 @@
   "predef": [
     "document",
     "window",
-    "-Promise"
+    "-Promise",
+    "Mousetrap"
   ],
   "browser": true,
   "boss": true,

--- a/addon/mixins/mousetrap-route.js
+++ b/addon/mixins/mousetrap-route.js
@@ -4,12 +4,12 @@ export default Ember.Mixin.create({
   mergedProperties: ['shortcuts'],
 
   mousetrapBindKeys: Ember.on('activate', function() {
-    if (!this.shortcuts) return;
+    if (!this.shortcuts) { return; }
 
     Ember.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];
 
-      if (!callback.__ember_mousetrap__) return;
+      if (!callback.__ember_mousetrap__) { return; }
 
       var keys   = callback.__ember_mousetrap__.keys;
       var action = callback.__ember_mousetrap__.action;
@@ -19,12 +19,12 @@ export default Ember.Mixin.create({
   }),
 
   mousetrapUnbindKeys: Ember.on('deactivate', function() {
-    if (!this.shortcuts) return;
+    if (!this.shortcuts) { return; }
 
     Ember.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];
 
-      if (!callback.__ember_mousetrap__) return;
+      if (!callback.__ember_mousetrap__) { return; }
 
       var keys = callback.__ember_mousetrap__.keys;
 


### PR DESCRIPTION
`ember build` shows the following warning messages:
```
modules/ember-mousetrap/mixins/mousetrap-route.js: line 7, col 26, Expected '{' and instead saw 'return'.
modules/ember-mousetrap/mixins/mousetrap-route.js: line 12, col 42, Expected '{' and instead saw 'return'.
modules/ember-mousetrap/mixins/mousetrap-route.js: line 22, col 26, Expected '{' and instead saw 'return'.
modules/ember-mousetrap/mixins/mousetrap-route.js: line 27, col 42, Expected '{' and instead saw 'return'.
modules/ember-mousetrap/mixins/mousetrap-route.js: line 17, col 7, 'Mousetrap' is not defined.
modules/ember-mousetrap/mixins/mousetrap-route.js: line 31, col 7, 'Mousetrap' is not defined.

6 errors
```

These commits will suppress it.