### PR TITLE
Fastboot compatibility

### DIFF
--- a/addon/mixins/mousetrap-route.js
+++ b/addon/mixins/mousetrap-route.js
@@ -4,7 +4,7 @@ export default Ember.Mixin.create({
   mergedProperties: ['shortcuts'],
 
   mousetrapBindKeys: Ember.on('activate', function() {
-    if (typeof FastBoot !== undefined || !this.shortcuts) { return; }
+    if (typeof FastBoot !== 'undefined' || !this.shortcuts) { return; }
 
     Object.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];
@@ -19,7 +19,7 @@ export default Ember.Mixin.create({
   }),
 
   mousetrapUnbindKeys: Ember.on('deactivate', function() {
-    if (typeof FastBoot !== undefined || !this.shortcuts) { return; }
+    if (typeof FastBoot !== 'undefined' || !this.shortcuts) { return; }
 
     Object.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];

--- a/addon/mixins/mousetrap-route.js
+++ b/addon/mixins/mousetrap-route.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
+  fastboot: Ember.inject.service(),
   mergedProperties: ['shortcuts'],
 
   mousetrapBindKeys: Ember.on('activate', function() {
-    if (!this.shortcuts) { return; }
+    if (this.get('fastboot.isFastBoot') || !this.shortcuts) { return; }
 
     Object.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];
@@ -19,7 +20,7 @@ export default Ember.Mixin.create({
   }),
 
   mousetrapUnbindKeys: Ember.on('deactivate', function() {
-    if (!this.shortcuts) { return; }
+    if (this.get('fastboot.isFastBoot') || !this.shortcuts) { return; }
 
     Object.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];

--- a/addon/mixins/mousetrap-route.js
+++ b/addon/mixins/mousetrap-route.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  fastboot: Ember.inject.service(),
   mergedProperties: ['shortcuts'],
 
   mousetrapBindKeys: Ember.on('activate', function() {
-    if (this.get('fastboot.isFastBoot') || !this.shortcuts) { return; }
+    if (typeof FastBoot !== undefined || !this.shortcuts) { return; }
 
     Object.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];
@@ -20,7 +19,7 @@ export default Ember.Mixin.create({
   }),
 
   mousetrapUnbindKeys: Ember.on('deactivate', function() {
-    if (this.get('fastboot.isFastBoot') || !this.shortcuts) { return; }
+    if (typeof FastBoot !== undefined || !this.shortcuts) { return; }
 
     Object.keys(this.shortcuts).forEach(function(key) {
       var callback = this.shortcuts[key];

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/mousetrap/mousetrap.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/mousetrap/mousetrap.js');
+    }
   }
 };


### PR DESCRIPTION
- Does not load the mousetrap library into the fastboot build
- Skips binding keys if running inside fastboot
- Skips unbinding keys if running inside fastboot